### PR TITLE
update 0.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - flit-core == 3.8.0
+    - flit-core 3.8.0
   run:
     - python
     - numpy >=1.17.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - flit-core
+    - flit-core == 3.8.0
   run:
     - python
     - numpy >=1.17.0
@@ -47,7 +47,7 @@ test:
     - pip check
 
 about:
-  home: https://github.com/QuantEcon/QuantEcon.py
+  home: https://quantecon.org/quantecon-py/
   license_url: https://github.com/QuantEcon/QuantEcon.py/blob/v{{ version }}/LICENSE
   license_family: BSD
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<37 or s390x]
+  # blosc2 is a dependency that is required for s390x but it is not available.
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.5.0" %}
-{% set sha256 = "5e49c2a23201924529533239ab999aca4f1380b7bf52ef3b2990ac652992b208" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "23033eb1734aceb6f420b5727e6e4cb78b99bf2414584d4039dd1a0c93eaebf0" %}
 
 package:
   name: quantecon
@@ -12,21 +12,24 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py<35]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<37]
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
+    - flit-core
   run:
     - python
-    - numpy
-    - scipy >=1.0.0
+    - numpy >=1.17.0
+    - scipy >=1.5.0
     - matplotlib-base
     - pandas
     - sympy
-    - numba >=0.38
+    - numba >=0.49.0
     - requests
     - nose
     - pytables
@@ -44,7 +47,6 @@ test:
 about:
   home: https://github.com/QuantEcon/QuantEcon.py
   license: BSD-3-Clause
-  license_file: LICENSE.txt 
   summary: QuantEcon is a package to support all forms of quantitative economic modelling.
   description: |
     **QuantEcon** is an organization run by economists for economists with the aim of coordinating

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ test:
 
 about:
   home: https://quantecon.org/quantecon-py/
-  license_url: https://github.com/QuantEcon/QuantEcon.py/blob/v{{ version }}/LICENSE
   license_family: BSD
   license: BSD-3-Clause
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<37]
+  skip: true  # [py<37 or s390x]
 
 requirements:
   host:
@@ -30,7 +30,6 @@ requirements:
     - sympy
     - numba >=0.49.0
     - requests
-    - cython
 
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,11 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
     - flit-core 3.8.0
   run:
     - python
     - numpy >=1.17.0
     - scipy >=1.5.0
-    - pandas
     - sympy
     - numba >=0.49.0
     - requests
@@ -42,7 +39,6 @@ test:
     - quantecon.util
   requires:
     - pip
-    - pytest
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ about:
   license_url: https://github.com/QuantEcon/QuantEcon.py/blob/v{{ version }}/LICENSE
   license_family: BSD
   license: BSD-3-Clause
+  license_file: LICENSE
   summary: QuantEcon is a package to support all forms of quantitative economic modelling.
   description: |
     **QuantEcon** is an organization run by economists for economists with the aim of coordinating

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,13 +26,11 @@ requirements:
     - python
     - numpy >=1.17.0
     - scipy >=1.5.0
-    - matplotlib-base
     - pandas
     - sympy
     - numba >=0.49.0
     - requests
-    - nose
-    - pytables
+    - cython
 
 
 test:
@@ -43,9 +41,16 @@ test:
     - quantecon.markov
     - quantecon.random
     - quantecon.util
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
 
 about:
   home: https://github.com/QuantEcon/QuantEcon.py
+  license_url: https://github.com/QuantEcon/QuantEcon.py/blob/v{{ version }}/LICENSE
+  license_family: BSD
   license: BSD-3-Clause
   summary: QuantEcon is a package to support all forms of quantitative economic modelling.
   description: |
@@ -58,7 +63,7 @@ about:
     The [repository](https://github.com/QuantEcon/QuantEcon.py>) includes the *conda-forge* build recipe for the *quantecon* python package.
 
     **Note:** There is also a Julia version available for Julia users [QuantEcon.jl](https://github.com/QuantEcon/QuantEcon.jl)
-  doc_url: http://quanteconpy.readthedocs.io/en/latest/
+  doc_url: https://quanteconpy.readthedocs.io/en/latest/
   dev_url: https://github.com/QuantEcon/QuantEcon.py
 
 extra:


### PR DESCRIPTION
## Quantecon 0.7.0 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1848)
[Upstream](https://github.com/QuantEcon/QuantEcon.py)
[Dependencies ](https://github.com/QuantEcon/QuantEcon.py/blob/main/pyproject.toml)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added skip for s390x as `numba` is not available.